### PR TITLE
スマホ表示時のみ表の文字が横向きになってしまうため再々修正

### DIFF
--- a/app/assets/stylesheets/studios.scss
+++ b/app/assets/stylesheets/studios.scss
@@ -1,14 +1,10 @@
 table {
-  writing-mode: vertical-lr;
-  white-space: pre;
   border-collapse: collapse;
   border: solid 1px #888;
   margin:20px;
   width:95%;
 }
 th, td {
-  writing-mode: horizontal-tb;
-  white-space: pre;
   padding: 5px 15px;
   border: solid 1px #888;
 }


### PR DESCRIPTION
スマホ表示時のみ表の文字が横向きになってしまうため再々修正